### PR TITLE
support shared step recursion

### DIFF
--- a/adotestplan_to_pytestbdd/ado_test_plan.py
+++ b/adotestplan_to_pytestbdd/ado_test_plan.py
@@ -1145,25 +1145,24 @@ class AzureDevOpsTestPlan:
         step_content = []
         # compare the element against the title?
         parameterized_string_elements = all_steps[0].findall("parameterizedString")
-        if parameterized_string_elements[0] is not None:
-            soup = BeautifulSoup(parameterized_string_elements[0].text, "html.parser")
-
-            # Find and extract the text content within the <P> element
-            p = soup.find("p")
-            if p:
-                content = p.get_text().strip()
-                if len(content):
-                    if content != title:
-                        content = self._ado_to_pytest_bdd_notation(content, id)
-                        step_content.append(
-                            f"# Shared step for {id}_Revision_{rev}: {title}"
-                        )  # noqa: E501
-                        step_content.append("\t\t" + content)
-                else:
-                    # likely a "then" where there is an expected result
-                    step_content = self._ado_to_pytest_bdd_notation(title, id)
+        # Find and extract the text content within the <P> element
+        p = BeautifulSoup(parameterized_string_elements[0].text, "html.parser").find(
+            "p"
+        )
+        if p:
+            content = p.get_text().strip()
+            if len(content):
+                if content != title:
+                    content = self._ado_to_pytest_bdd_notation(content, id)
+                    step_content.append(
+                        f"# Shared step for {id}_Revision_{rev}: {title}"
+                    )  # noqa: E501
+                    step_content.append("\t\t" + content)
             else:
+                # likely a "then" where there is an expected result
                 step_content = self._ado_to_pytest_bdd_notation(title, id)
+        else:
+            step_content = self._ado_to_pytest_bdd_notation(title, id)
         return step_content
 
     def _parse_shared_step_content(self, shared_step_item: WorkItem):

--- a/adotestplan_to_pytestbdd/ado_test_plan.py
+++ b/adotestplan_to_pytestbdd/ado_test_plan.py
@@ -1085,116 +1085,119 @@ class AzureDevOpsTestPlan:
         compref_steps.append(step)
         return compref_steps
 
+    def _process_multiple_shared_steps(self, all_steps, id, title, rev):
+        step_content = []
+        first_step = True
+        contents_found = False
+        for sub_step in all_steps:
+            if sub_step.tag == "compref":
+                if first_step:
+                    step_content.append(
+                        f"# Start Shared Steps for {id}: {title} Revision {rev}"
+                    )
+                    first_step = False
+                shared_step_id = sub_step.get("ref")
+                if shared_step_id not in self._shared_steps:
+                    logging.warning(
+                        f"recursively getting new shared step {shared_step_id}"
+                    )
+
+                    self._shared_steps[shared_step_id] = (
+                        self._parse_shared_step_content(
+                            self.witc.get_work_item(
+                                id=shared_step_id, project=self.project
+                            )
+                        )
+                    )
+                content = self._shared_steps[shared_step_id]
+                if "\t\t" not in content:
+                    content = "\t\t" + content
+                step_content.append(content)
+            elif sub_step.tag == "step":
+                parameterized_string_elements = sub_step.findall("parameterizedString")
+                if parameterized_string_elements[0] is not None:
+                    soup = BeautifulSoup(
+                        parameterized_string_elements[0].text, "html.parser"
+                    )
+
+                    # Find and extract the text content within the <P> element
+                    p = soup.find("p")
+                    if p:
+                        content = p.get_text().strip()
+                        if content != "":
+                            content = self._ado_to_pytest_bdd_notation(content, id)
+                            contents_found = True
+                            if first_step:
+                                step_content.append(
+                                    f"# Start Shared Steps for {id}: {title} Revision {rev}"
+                                )  # noqa: E501
+                                first_step = False
+                            step_content.append("\t\t" + content)
+                        else:
+                            logging.warning(f"Empty step in {title}")
+        if not first_step:
+            step_content.append(f"\t\t# End Shared Steps for {id}")
+        if not contents_found:
+            logging.warning(f"Full contents of substep is empty for:\{title}")
+        return step_content
+
+    def _process_single_shared_steps(self, all_steps, id, title, rev):
+        step_content = []
+        # compare the element against the title?
+        parameterized_string_elements = all_steps[0].findall("parameterizedString")
+        if parameterized_string_elements[0] is not None:
+            soup = BeautifulSoup(parameterized_string_elements[0].text, "html.parser")
+
+            # Find and extract the text content within the <P> element
+            p = soup.find("p")
+            if p:
+                content = p.get_text().strip()
+                if len(content):
+                    if content != title:
+                        content = self._ado_to_pytest_bdd_notation(content, id)
+                        step_content.append(
+                            f"# Shared step for {id}_Revision_{rev}: {title}"
+                        )  # noqa: E501
+                        step_content.append("\t\t" + content)
+                else:
+                    # likely a "then" where there is an expected result
+                    step_content = self._ado_to_pytest_bdd_notation(title, id)
+            else:
+                step_content = self._ado_to_pytest_bdd_notation(title, id)
+        return step_content
+
     def _parse_shared_step_content(self, shared_step_item: WorkItem):
         """This subroutine takes a shared step work item and parses out
         every step from that work item into a list to populate step content with"""
         step_content = []
         title = shared_step_item.fields["System.Title"]
-        if "Microsoft.VSTS.TCM.Steps" in shared_step_item.fields:
-            possible_sub_steps = shared_step_item.fields["Microsoft.VSTS.TCM.Steps"]
-            sub_root = ET.fromstring(possible_sub_steps)
-
-            sub_all_elements = self._collect_steps_and_comprefs(sub_root)
-            contents_found = False
-            if len(sub_all_elements) > 1:
-                first_step = True
-
-                for sub_step in sub_all_elements:
-                    if sub_step.tag == "compref":
-                        if first_step:
-                            step_content.append(
-                                f"# Start Shared Steps for {shared_step_item.id}: {title} Revision {shared_step_item.rev}"
-                            )
-                            first_step = False
-                        shared_step_id = sub_step.get("ref")
-                        if shared_step_id not in self._shared_steps:
-                            logging.warning(
-                                f"recursively getting new shared step {shared_step_id}"
-                            )
-
-                            self._shared_steps[shared_step_id] = (
-                                self._parse_shared_step_content(
-                                    self.witc.get_work_item(
-                                        id=shared_step_id, project=self.project
-                                    )
-                                )
-                            )
-                        content = self._shared_steps[shared_step_id]
-                        if "\t\t" not in content:
-                            content = "\t\t" + content
-                        step_content.append(content)
-                    elif sub_step.tag == "step":
-                        parameterized_string_elements = sub_step.findall(
-                            "parameterizedString"
-                        )
-                        if parameterized_string_elements[0] is not None:
-                            soup = BeautifulSoup(
-                                parameterized_string_elements[0].text, "html.parser"
-                            )
-
-                            # Find and extract the text content within the <P> element
-                            p = soup.find("p")
-                            if p:
-                                content = p.get_text().strip()
-                                if content != "":
-                                    content = self._ado_to_pytest_bdd_notation(
-                                        content, shared_step_item.id
-                                    )
-                                    contents_found = True
-                                    if first_step:
-                                        step_content.append(
-                                            f"# Start Shared Steps for {shared_step_item.id}: {title} Revision {shared_step_item.rev}"
-                                        )  # noqa: E501
-                                        first_step = False
-                                    step_content.append("\t\t" + content)
-                                else:
-                                    logging.warning(f"Empty step in {title}")
-                if not first_step:
-                    step_content.append(
-                        f"\t\t# End Shared Steps for {shared_step_item.id}"
-                    )
-                if not contents_found:
-                    logging.warning(
-                        f"Full contents of substep is empty for:\
-    {title}"
-                    )
-            else:
-                if len(sub_all_elements) == 1:
-                    # compare the element against the title?
-                    parameterized_string_elements = sub_all_elements[0].findall(
-                        "parameterizedString"
-                    )
-                    if parameterized_string_elements[0] is not None:
-                        soup = BeautifulSoup(
-                            parameterized_string_elements[0].text, "html.parser"
-                        )
-
-                        # Find and extract the text content within the <P> element
-                        p = soup.find("p")
-                        if p:
-                            content = p.get_text().strip()
-                            if len(content):
-                                if content != title:
-                                    content = self._ado_to_pytest_bdd_notation(
-                                        content, shared_step_item.id
-                                    )
-                                    step_content.append(
-                                        f"# Shared step for {shared_step_item.id}_Revision_{shared_step_item.rev}: {title}"
-                                    )  # noqa: E501
-                                    step_content.append("\t\t" + content)
-                                    return step_content
-                            else:
-                                # likely a "then" where there is an expected result
-                                content = self._ado_to_pytest_bdd_notation(
-                                    title, shared_step_item.id
-                                )
-                                return content
-                content = self._ado_to_pytest_bdd_notation(title, shared_step_item.id)
-                return content
-            return step_content
+        self._shared_step_depth += 1
+        if self._shared_step_depth > 10:
+            raise RecursionError(
+                f"Too many nested shared steps, detected while processing {shared_step_item.id} ({title})"
+            )
+        elif "Microsoft.VSTS.TCM.Steps" in shared_step_item.fields:
+            steps_root = ET.fromstring(
+                shared_step_item.fields["Microsoft.VSTS.TCM.Steps"]
+            )
+            all_steps = self._collect_steps_and_comprefs(steps_root)
+            if len(all_steps) > 1:
+                step_content = self._process_multiple_shared_steps(
+                    all_steps, shared_step_item.id, title
+                )
+            elif len(all_steps) == 1:
+                step_content = self._process_single_shared_step(
+                    all_steps, shared_step_item.id, title, shared_step_item.rev
+                )
+            else:  # no steps - use the work-item title as the step contents
+                step_content = self._ado_to_pytest_bdd_notation(
+                    title, shared_step_item.id
+                )
         else:
-            content = self._ado_to_pytest_bdd_notation(title, shared_step_item.id)
-            return [content]
+            step_content = [
+                self._ado_to_pytest_bdd_notation(title, shared_step_item.id)
+            ]
+        return step_content
 
     @timebudget
     def _get_azure_shared_steps(self):
@@ -1220,6 +1223,7 @@ class AzureDevOpsTestPlan:
                 if id in self._shared_steps:
                     logging.info(f"already fetched shared step {id}")
                 else:
+                    self._shared_step_depth = 0
                     self._shared_steps[id] = self._parse_shared_step_content(
                         shared_step_item
                     )

--- a/adotestplan_to_pytestbdd/ado_test_plan.py
+++ b/adotestplan_to_pytestbdd/ado_test_plan.py
@@ -1101,7 +1101,6 @@ class AzureDevOpsTestPlan:
                     logging.warning(
                         f"recursively getting new shared step {shared_step_id}"
                     )
-
                     self._shared_steps[shared_step_id] = (
                         self._parse_shared_step_content(
                             self.witc.get_work_item(
@@ -1109,10 +1108,13 @@ class AzureDevOpsTestPlan:
                             )
                         )
                     )
+
                 content = self._shared_steps[shared_step_id]
-                if "\t\t" not in content:
+                if isinstance(content, list) and len(content):
+                    step_content.extend(content)
+                elif len(content) and "\t\t" not in content:
                     content = "\t\t" + content
-                step_content.append(content)
+                    step_content.append(content)
             elif sub_step.tag == "step":
                 parameterized_string_elements = sub_step.findall("parameterizedString")
                 if parameterized_string_elements[0] is not None:
@@ -1189,6 +1191,10 @@ class AzureDevOpsTestPlan:
             elif len(all_steps) == 1:
                 step_content = self._process_single_shared_step(
                     all_steps, shared_step_item.id, title, shared_step_item.rev
+                )
+            else:  # no steps - use the work-item title as the step contents
+                step_content = self._ado_to_pytest_bdd_notation(
+                    title, shared_step_item.id
                 )
         else:
             step_content = [

--- a/adotestplan_to_pytestbdd/ado_test_plan.py
+++ b/adotestplan_to_pytestbdd/ado_test_plan.py
@@ -1141,29 +1141,28 @@ class AzureDevOpsTestPlan:
             logging.warning(f"Full contents of substep is empty for:\{title}")
         return step_content
 
-    def _process_single_shared_steps(self, all_steps, id, title, rev):
+    def _process_single_shared_step(self, all_steps, id, title, rev):
         step_content = []
         # compare the element against the title?
         parameterized_string_elements = all_steps[0].findall("parameterizedString")
-        if parameterized_string_elements[0] is not None:
-            soup = BeautifulSoup(parameterized_string_elements[0].text, "html.parser")
-
-            # Find and extract the text content within the <P> element
-            p = soup.find("p")
-            if p:
-                content = p.get_text().strip()
-                if len(content):
-                    if content != title:
-                        content = self._ado_to_pytest_bdd_notation(content, id)
-                        step_content.append(
-                            f"# Shared step for {id}_Revision_{rev}: {title}"
-                        )  # noqa: E501
-                        step_content.append("\t\t" + content)
-                else:
-                    # likely a "then" where there is an expected result
-                    step_content = self._ado_to_pytest_bdd_notation(title, id)
+        # Find and extract the text content within the <P> element
+        p = BeautifulSoup(parameterized_string_elements[0].text, "html.parser").find(
+            "p"
+        )
+        if p:
+            content = p.get_text().strip()
+            if len(content):
+                if content != title:
+                    content = self._ado_to_pytest_bdd_notation(content, id)
+                    step_content.append(
+                        f"# Shared step for {id}_Revision_{rev}: {title}"
+                    )  # noqa: E501
+                    step_content.append("\t\t" + content)
             else:
+                # likely a "then" where there is an expected result
                 step_content = self._ado_to_pytest_bdd_notation(title, id)
+        else:
+            step_content = self._ado_to_pytest_bdd_notation(title, id)
         return step_content
 
     def _parse_shared_step_content(self, shared_step_item: WorkItem):
@@ -1183,7 +1182,7 @@ class AzureDevOpsTestPlan:
             all_steps = self._collect_steps_and_comprefs(steps_root)
             if len(all_steps) > 1:
                 step_content = self._process_multiple_shared_steps(
-                    all_steps, shared_step_item.id, title
+                    all_steps, shared_step_item.id, title, shared_step_item.rev
                 )
             elif len(all_steps) == 1:
                 step_content = self._process_single_shared_step(

--- a/adotestplan_to_pytestbdd/ado_test_plan.py
+++ b/adotestplan_to_pytestbdd/ado_test_plan.py
@@ -1158,6 +1158,8 @@ class AzureDevOpsTestPlan:
                         f"# Shared step for {id}_Revision_{rev}: {title}"
                     )  # noqa: E501
                     step_content.append("\t\t" + content)
+                else:
+                    step_content = self._ado_to_pytest_bdd_notation(title, id)
             else:
                 # likely a "then" where there is an expected result
                 step_content = self._ado_to_pytest_bdd_notation(title, id)
@@ -1187,10 +1189,6 @@ class AzureDevOpsTestPlan:
             elif len(all_steps) == 1:
                 step_content = self._process_single_shared_step(
                     all_steps, shared_step_item.id, title, shared_step_item.rev
-                )
-            else:  # no steps - use the work-item title as the step contents
-                step_content = self._ado_to_pytest_bdd_notation(
-                    title, shared_step_item.id
                 )
         else:
             step_content = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "adotestplan-to-pytestbdd"
-version = "0.1.8"
+version = "0.1.9"
 description = "Utility for translating AzureDevOps Test Plans to Gherkin Feature file and Pytest-BDD runners"
 authors = [
     "David VanKampen <david.vankampen@bissell.com>",


### PR DESCRIPTION
Though the ADO Web UI does not allow shared steps to reference other shared steps, you can create the same links via the REST API, thus introducing recursion (shared steps referencing other shared steps). 

I also encapsulated the compref reading step into `_follow_compref` on the off-chance that we wanted to do the recursive search immediately.  I am not doing that today, but I will leave that subroutine there as a breadcrumb for if/when we do want to do it that way.